### PR TITLE
fixed compatibility with new 4chan sfw domain

### DIFF
--- a/ddt.meta.js
+++ b/ddt.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         DesuDesuTalk
 // @namespace    udp://desushelter/*
-// @version      0.4.86
+// @version      0.4.87
 // @description  Write something useful!
 // @include      *://dobrochan.com/*/*
 // @include      *://dobrochan.ru/*/*
@@ -20,6 +20,7 @@
 // @include      *://syn-ch.ru/*/*
 // @include      *://krautchan.net/*/*
 // @include      *://boards.4chan.org/*/*
+// @include      *://boards.4channel.org/*/*
 // @include      *://2ch.hk/*/*
 // @include      *://2ch.re/*/*
 // @include      *://2ch.pm/*/*

--- a/ddt.user.js
+++ b/ddt.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         DesuDesuTalk
 // @namespace    udp://desushelter/*
-// @version      0.4.86
+// @version      0.4.87
 // @description  Write something useful!
 // @include      *://dobrochan.com/*/*
 // @include      *://dobrochan.ru/*/*
@@ -20,6 +20,7 @@
 // @include      *://syn-ch.ru/*/*
 // @include      *://krautchan.net/*/*
 // @include      *://boards.4chan.org/*/*
+// @include      *://boards.4channel.org/*/*
 // @include      *://2ch.hk/*/*
 // @include      *://2ch.re/*/*
 // @include      *://2ch.pm/*/*


### PR DESCRIPTION
4chan added a new domain at [boards.4channel.org](boards.4channel.org) to which all sfw boards will migrate. 
Hence i propose this PR; it adds a new match rule for the new domain scheme.